### PR TITLE
Property options

### DIFF
--- a/addon/components/property-options/component.js
+++ b/addon/components/property-options/component.js
@@ -1,0 +1,64 @@
+import Ember from 'ember';
+
+export default Ember.Component.extend({
+  tagName: '',
+  isVisible: true,
+  init() {
+    this._super(...arguments);
+    let property = this.get('property.property');
+    let document = this.get('document');
+
+    if (!property.isDependentProperty) {
+      return;
+    }
+
+    this.setProperties({
+      isDependentProperty: true,
+      dependsOnProperties: property.dependsOnProperties
+    });
+
+    // If this property depends on other values, set up observers.
+    // REVIEW: It would be ideal to do this with computeds, but it's not clear
+    // how to set up computeds for either all child properties of an object or
+    // an a run-time generated object key.
+
+    property.dependsOnProperties.forEach((dependsOn) => {
+      let callback = Ember.run.bind(this, this._onUpdatedMasterProperty);
+      document.values.addObserver(dependsOn.documentPath, callback);
+    });
+
+    this._onUpdatedMasterProperty();
+  },
+
+  propertyOptions: Ember.computed('isVisible', function() {
+    let isVisible = this.get('isVisible');
+    return { isVisible };
+  }),
+
+  willDestroyElement() {
+    this._super(...arguments);
+
+    let property = this.get('property.property');
+    let document = this.get('document');
+
+    if (!property.isDependentProperty) {
+      return;
+    }
+
+    property.dependsOnProperties.forEach((dependsOn) => {
+      let callback = Ember.run.bind(this, this._onUpdatedMasterProperty);
+      document.values.removeObserver(dependsOn.documentPath, callback);
+    });
+  },
+
+  _onUpdatedMasterProperty() {
+    let property = this.get('property.property');
+    let document = this.get('document');
+
+    let isVisible = property.dependsOnProperties.filter((dependsOn) => {
+      return !!document.get(dependsOn.documentPath);
+    }).length > 0;
+
+    this.setProperties({ isVisible });
+  }
+});

--- a/app/components/property-options/component.js
+++ b/app/components/property-options/component.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-json-schema-views/components/property-options/component';

--- a/app/templates/components/each-property.hbs
+++ b/app/templates/components/each-property.hbs
@@ -1,9 +1,11 @@
 {{#each propertyCollection as |property|}}
-  {{#if property.childProperties}}
-    {{#each-property properties=property.childProperties as |childKey childProperty childType|}}
-      {{yield (concat (concat property.key '.') childKey) childProperty childType}}
-    {{/each-property}}
-  {{else}}
-    {{yield property.key property.property property.type}}
-  {{/if}}
+  {{#property-options document=document property=property as |propertyOptions property document|}}
+    {{#if property.childProperties}}
+      {{#each-property properties=property.childProperties document=document as |childKey childProperty childType childOptions|}}
+        {{yield (concat (concat property.key '.') childKey) childProperty childType childOptions}}
+      {{/each-property}}
+    {{else}}
+      {{yield property.key property.property property.type propertyOptions}}
+    {{/if}}
+  {{/property-options}}
 {{/each}}

--- a/app/templates/components/property-options.hbs
+++ b/app/templates/components/property-options.hbs
@@ -1,0 +1,1 @@
+{{yield propertyOptions property document}}

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "license": "MIT",
   "devDependencies": {
     "broccoli-asset-rev": "^2.2.0",
-    "ember-json-schema-document": "0.0.2",
+    "ember-json-schema-document": "0.1.0",
     "ember-cli": "1.13.14",
     "ember-cli-app-version": "^1.0.0",
     "ember-cli-content-security-policy": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-json-schema-views",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "The default blueprint for ember-cli addons.",
   "directories": {
     "test": "tests"

--- a/tests/integration/components/each-property-test.js
+++ b/tests/integration/components/each-property-test.js
@@ -136,7 +136,7 @@ test('can render flat schema document properties', function(assert) {
   this.setProperties({ document, properties });
 
   this.render(hbs`
-    {{#each-property properties=properties as |key property type|}}
+    {{#each-property properties=properties document=document as |key property type|}}
       {{component (concat 'schema-field-' type) key=key property=property document=document}}
     {{/each-property}}
   `);
@@ -159,7 +159,7 @@ test('can render nested schema document properties', function(assert) {
   this.setProperties({ document, properties });
 
   this.render(hbs`
-    {{#each-property properties=properties as |key property type|}}
+    {{#each-property properties=properties document=document as |key property type|}}
       {{component (concat 'schema-field-' type) key=key property=property document=document}}
     {{/each-property}}
   `);

--- a/tests/integration/dependent-properties-test.js
+++ b/tests/integration/dependent-properties-test.js
@@ -56,8 +56,10 @@ test('renders dependent properties', function(assert) {
   this.setProperties({ document, properties });
 
   this.render(hbs`
-    {{#each-property properties=properties document=document as |key property type|}}
-      {{component (concat 'schema-field-' type) key=key property=property document=document}}
+    {{#each-property properties=properties document=document as |key property type options|}}
+      {{#if options.isVisible}}
+        {{component (concat 'schema-field-' type) key=key property=property document=document}}
+      {{/if}}
     {{/each-property}}
   `);
 

--- a/tests/integration/dependent-properties-test.js
+++ b/tests/integration/dependent-properties-test.js
@@ -1,0 +1,75 @@
+import { moduleForComponent, test } from 'ember-qunit';
+import Schema from 'ember-json-schema-document/models/schema';
+import hbs from 'htmlbars-inline-precompile';
+import Ember from 'ember';
+
+Error.stackTraceLimit = 100;
+
+let schemaBody = {
+  '$schema': 'http://json-schema.org/draft-04/schema#',
+  'id': 'http://jsonschema.net',
+  'type': 'object',
+  'properties': {
+    'vulnerabilityScanner': {
+      'type': 'object',
+      'properties': {
+        'usesVulnerabilityScanners': {
+          'type': 'boolean',
+          'default': false,
+          'displayProperties': {
+            'title': 'Do you use vulnerability scanners?'
+          }
+        },
+
+        'provider': {
+          'title': 'Which provider do you use?',
+          'type': 'text'
+        },
+
+        'frequency': {
+          'title': 'How often do you scan?',
+          'type': 'text',
+          'enum': ['Daily', 'Weekly', 'Monthly', 'Semi-annually', 'Annually']
+        }
+      },
+
+      'required': [
+        'usesVulnerabilityScanners'
+      ],
+
+      'dependencies': {
+        'usesVulnerabilityScanners': ['provider', 'frequency']
+      }
+    }
+  }
+};
+
+moduleForComponent('each-property', {
+  integration: true
+});
+
+test('renders dependent properties', function(assert) {
+  let schema = new Schema(schemaBody);
+  let { properties } = schema;
+  let document = schema.buildDocument();
+
+  this.setProperties({ document, properties });
+
+  this.render(hbs`
+    {{#each-property properties=properties document=document as |key property type|}}
+      {{component (concat 'schema-field-' type) key=key property=property document=document}}
+    {{/each-property}}
+  `);
+
+  assert.equal(this.$('input[name="vulnerabilityScanner.usesVulnerabilityScanners"]').length, 2, 'shows initial toggle');
+  assert.equal(this.$('input[name="vulnerabilityScanner.provider"]').length, 0, 'doesn\'t show provider');
+  assert.equal(this.$('select[name="vulnerabilityScanner.frequency"]').length, 0, 'doesn\'t show frequency select');
+
+  Ember.run(() => {
+    this.$('input[name="vulnerabilityScanner.usesVulnerabilityScanners"][value="true"]').click();
+    this.$('input[name="vulnerabilityScanner.usesVulnerabilityScanners"]').trigger('change');
+  });
+
+  assert.equal(this.$('input[name="vulnerabilityScanner.provider"]').length, 1, 'shows provider');
+  assert.equal(this.$('select[name="vulnerabilityScanner.frequency"]').length, 1, 'shows frequency select');
+});


### PR DESCRIPTION
This PR adds a new `property-options` component that does the work to inspecting property dependencies and determine property visibility.  Visibility is not actually enforced, it is instead yielded down to consumers of `{{#each-property}}` as an options block.  This affords the consuming app to do interesting things with visibility, like fadeOut.
