### PR TITLE
Disable recursive

### DIFF
--- a/addon/components/each-property/component.js
+++ b/addon/components/each-property/component.js
@@ -22,16 +22,17 @@ export function getPropertyInputType(property) {
 
 export default Ember.Component.extend({
   tagName: '',
-
+  recursive: true,
   propertyCollection: Ember.computed('properties.[]', function() {
-    let propertyHash = this.get('properties');
-    let propertyKeys = Object.keys(propertyHash);
+    let { properties, recursive } = this.getProperties('properties', 'recursive');
+    let propertyKeys = Object.keys(properties);
 
     return propertyKeys.map((key) => {
-      let property = propertyHash[key];
+      let property = properties[key];
+      let showChildProperties = recursive && property.properties;
 
       return { key, property, type: getPropertyInputType(property),
-               childProperties: property.properties };
+               showChildProperties, childProperties: property.properties };
     });
   })
 });

--- a/app/templates/components/each-property.hbs
+++ b/app/templates/components/each-property.hbs
@@ -1,11 +1,13 @@
 {{#each propertyCollection as |property|}}
-  {{#property-options document=document property=property as |propertyOptions property document|}}
-    {{#if property.childProperties}}
+  {{#property-options document=document property=property as |propertyOptions document|}}
+
+    {{#if property.showChildProperties}}
       {{#each-property properties=property.childProperties document=document as |childKey childProperty childType childOptions|}}
         {{yield (concat (concat property.key '.') childKey) childProperty childType childOptions}}
       {{/each-property}}
     {{else}}
       {{yield property.key property.property property.type propertyOptions}}
     {{/if}}
+
   {{/property-options}}
 {{/each}}

--- a/app/templates/components/property-options.hbs
+++ b/app/templates/components/property-options.hbs
@@ -1,1 +1,1 @@
-{{yield propertyOptions property document}}
+{{yield propertyOptions document}}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-json-schema-views",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "The default blueprint for ember-cli addons.",
   "directories": {
     "test": "tests"

--- a/tests/integration/components/each-property-test.js
+++ b/tests/integration/components/each-property-test.js
@@ -173,3 +173,25 @@ test('can render nested schema document properties', function(assert) {
   assert.equal(this.$('select[name="address.state"] option').length, 6, 'has 6 choices');
   assert.equal(this.$('input[type="text"][name="address.zip"]').length, 1, 'has a zip text field');
 });
+
+test('`recrusive=false` will prevent recursively iterating child properties', function(assert) {
+  let schema = new Schema(nestedSchema);
+  let { properties } = schema;
+  let document = schema.buildDocument();
+
+  this.setProperties({ document, properties });
+
+  this.render(hbs`
+    {{#each-property properties=properties document=document recursive=false as |key property type|}}
+      {{component (concat 'schema-field-' type) key=key property=property document=document}}
+    {{/each-property}}
+  `);
+
+  assert.equal(this.$('input[type="radio"][name="primaryLocation"]').length, 2, 'has two radios');
+  assert.equal(this.$('.x-toggle-btn').length, 1, 'has a toggle button');
+  assert.equal(this.$('input[type="text"][name="description"]').length, 1, 'has a description text field');
+  assert.equal(this.$('input[type="text"][name="description"]').val(), 'Headquarters', 'description has default value');
+  assert.equal(this.$('input[type="text"][name="address.city"]').length, 0, 'no city text field present');
+  assert.equal(this.$('select[name="address.state"]').length, 0, 'no state select present');
+  assert.equal(this.$('input[type="text"][name="address.zip"]').length, 0, 'no zip text field present');
+});


### PR DESCRIPTION
Previously, `{{#each-property}}` would always recursively iterate schema properties.  This can make it hard for the client to manage different views for nested properties. This PR adds a new property to `{{#each-property}}` that will optionally disable recursing all descendent properties.
