### PR TITLE
Set default value

### DIFF
--- a/addon/components/property-options/component.js
+++ b/addon/components/property-options/component.js
@@ -60,8 +60,31 @@ export default Ember.Component.extend({
 
     this.setProperties({ showProperty });
 
-    if (!showProperty) {
+    if (showProperty) {
+      this._setDefaultValue();
+    } else {
       document.set(property.documentPath, null);
+    }
+  },
+
+  _setDefaultValue() {
+    let document = this.get('document');
+    let property = this.get('property.property');
+    let defaultValue = this.get('property.default');
+    let value;
+
+    if (!Ember.isNone(document.get(property.documentPath))) {
+      return;
+    }
+
+    if (Ember.isNone(defaultValue)) {
+      value = { 'array': [], 'string': '', 'object': {} }[property.type];
+    } else {
+      value = defaultValue;
+    }
+
+    if (!Ember.isNone(value)) {
+      document.set(property.documentPath, value);
     }
   }
 });

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "ember-disable-prototype-extensions": "^1.0.0",
     "ember-disable-proxy-controllers": "^1.0.1",
     "ember-export-application-global": "^1.0.4",
-    "ember-json-schema-document": "0.1.3",
+    "ember-json-schema-document": "0.1.4",
     "ember-multiselect-checkboxes": "0.8.0",
     "ember-one-way-input": "0.3.0",
     "ember-radio-button": "1.0.7",


### PR DESCRIPTION
Since we are using a outside-the-spec property dependencies, we need a new way to enforce validation on dependent properties.  We can do this in two steps:

1)  When a dependent property becomes visible (aka required), set it to a non-null initial value, e.g. `[]` for array properties.
2)  Allow dependent properties to be null, but when not-null, validate.  For example, an array-typed dependent property can be null, but it can't be empty.

This PR updates dependent properties to set an initial value when toggled, forcing the property to be validated.
