### PR TITLE
Allow array property values to be used to satisfy dependency checks

### DIFF
--- a/addon/components/property-options/component.js
+++ b/addon/components/property-options/component.js
@@ -54,8 +54,20 @@ export default Ember.Component.extend({
     let dependencyCount = property.dependsOnProperties.length;
 
     let showProperty = property.dependsOnProperties.filter((dependsOn) => {
+      // `dependsOn.values` is an array of required values.  If the property's
+      // current value is included in this array, it is now required
       let currentValue = document.get(dependsOn.property.documentPath);
-      return dependsOn.values.indexOf(currentValue) > -1;
+
+      if (dependsOn.property.type === 'array') {
+        // For array types, we are checking to see if any of the current values
+        // are included in `dependsOn.values`.
+        return currentValue.filter((value) => {
+          return dependsOn.values.indexOf(value) > -1;
+        }).length > 0;
+      } else {
+        return dependsOn.values.indexOf(currentValue) > -1;
+      }
+
     }).length === dependencyCount;
 
     this.setProperties({ showProperty });

--- a/tests/integration/dependent-properties-test.js
+++ b/tests/integration/dependent-properties-test.js
@@ -2,6 +2,39 @@ import { moduleForComponent, test } from 'ember-qunit';
 import Schema from 'ember-json-schema-document/models/schema';
 import hbs from 'htmlbars-inline-precompile';
 
+let arrayDependencySchema = {
+  '$schema': 'http://json-schema.org/draft-04/schema#',
+  'id': 'http://jsonschema.net',
+  'type': 'object',
+  'properties': {
+    'vulnerabilityScanner': {
+      'type': 'object',
+      'properties': {
+        'provider': {
+          'type': 'array',
+          'title': 'Which provider do you use?',
+          'items': {
+            'type': 'string',
+            'enum': [
+              'Amazon',
+              'Google',
+              'Other'
+            ]
+          }
+        },
+
+        'other': {
+          'title': 'Which other provider do you use?',
+          'type': 'text'
+        }
+      },
+
+      'required': [ 'provider' ],
+      '_dependencies': { 'other': { 'provider': 'Other' } }
+    }
+  }
+};
+
 let schemaBody = {
   '$schema': 'http://json-schema.org/draft-04/schema#',
   'id': 'http://jsonschema.net',
@@ -79,4 +112,26 @@ test('renders dependent properties', function(assert) {
   assert.equal(this.$('select[name="vulnerabilityScanner.frequency"]').length, 1, 'shows frequency select');
   assert.equal(this.$('input[name="vulnerabilityScanner.whyNot"]').length, 0, 'doesn\'t shows whynot text');
 
+});
+
+test('renders dependent properties with array values', function(assert) {
+  let schema = new Schema(arrayDependencySchema);
+  let { properties } = schema;
+  let document = schema.buildDocument();
+
+  this.setProperties({ document, properties });
+
+  this.render(hbs`
+    {{#each-property properties=properties document=document as |key property type options|}}
+      {{#if options.showProperty}}
+        {{component (concat 'schema-field-' type) key=key property=property document=document}}
+      {{/if}}
+    {{/each-property}}
+  `);
+
+  assert.equal(this.$('.checkbox label span:contains(Amazon)').length, 1, 'shows provider options');
+  assert.equal(this.$('input[name="vulnerabilityScanner.other"]').length, 0, 'doesn\'t show other');
+
+  this.$('.checkbox label span:contains(Other)').click();
+  assert.equal(this.$('input[name="vulnerabilityScanner.other"]').length, 1, 'other is visible');
 });


### PR DESCRIPTION
This PR updates dependent value visibility checks top support array values.  The additional integration test is a good example of the use case.  When selecting from a list  of checkboxes, it should be possible that any one of the values selected could trigger a dependent property to become required. In this case, selecting "Other" from the list of providers will trigger a dependent text field to render.
