### PR TITLE
Update each-property to yield for all properties, not just leaf nodes

### DIFF
--- a/app/templates/components/each-property.hbs
+++ b/app/templates/components/each-property.hbs
@@ -1,12 +1,12 @@
 {{#each propertyCollection as |property|}}
   {{#property-options document=document property=property as |propertyOptions document|}}
 
+    {{yield property.key property.property property.type propertyOptions}}
+
     {{#if property.showChildProperties}}
       {{#each-property properties=property.childProperties document=document as |childKey childProperty childType childOptions|}}
         {{yield (concat (concat property.key '.') childKey) childProperty childType childOptions}}
       {{/each-property}}
-    {{else}}
-      {{yield property.key property.property property.type propertyOptions}}
     {{/if}}
 
   {{/property-options}}


### PR DESCRIPTION
Without this PR, `{{#each-property}}` doesn't yield `object` properties and instead just recursively yields the objects children.  That works ok in our exact use case, but isn't a great generic implementation. This PR updates `{{#each-property}}` to yield all schema properties, even if they have children. 
