### PR TITLE
Make select component consistent with default HTML select

### DIFF
--- a/addon/components/schema-field-select/component.js
+++ b/addon/components/schema-field-select/component.js
@@ -2,6 +2,23 @@ import Ember from 'ember';
 import SchemaFieldInitializerMixin from 'ember-json-schema-views/mixins/components/schema-field-initializer';
 
 export default Ember.Component.extend(SchemaFieldInitializerMixin, {
+  init() {
+    this._super(...arguments);
+    let { key, property, document } = this.getProperties(['key', 'property', 'document']);
+
+    if (typeof document.get(key) !== 'undefined' && document.get(key) !== '') {
+      return;
+    }
+
+    if (!Ember.getWithDefault(property, 'displayProperties.prompt', false)) {
+      // No value set and no prompt set.  We should select the first value
+      let [initialValue] = property.validValues;
+      document.set(key, initialValue);
+      this.set('value', initialValue);
+    }
+
+  },
+
   classNames: ['schema-field-component', 'schema-field-select'],
   getCurrentValue() {
     return this.$('select').val();

--- a/tests/integration/components/schema-field-select-test.js
+++ b/tests/integration/components/schema-field-select-test.js
@@ -52,6 +52,18 @@ let objectSchema = {
   ]
 };
 
+let noDefaultStateProperty = Ember.$.extend(true, {}, stateProperty);
+delete noDefaultStateProperty.default;
+
+let selectWithoutPrompt = {
+  '$schema': 'http://json-schema.org/draft-04/schema#',
+  'id': 'http://jsonschema.net',
+  'type': 'object',
+  'properties': {
+    'state': noDefaultStateProperty
+  }
+};
+
 let disabledPropertySchema = {
   'type': 'object',
   'properties': {
@@ -271,4 +283,16 @@ test('When `readonly` is false, select should not be disabled', function(assert)
   assert.ok(!select.is(':disabled'), 'select is not disabled');
   assert.equal(select.val(), 'IN', 'default value is used in select');
   assert.equal(document.get('state'), 'IN', 'document value is correct');
+});
+
+test('When a display prompt and default value are missing, use first valid value as default value', function(assert) {
+  let schema = new Schema(selectWithoutPrompt);
+  let document = schema.buildDocument();
+  let property = schema.properties.state;
+  let [expected] = noDefaultStateProperty.enum;
+
+  this.setProperties({ key: 'state', property, document });
+  this.render(hbs('{{schema-field-select key=key property=property document=document}}'));
+
+  assert.equal(document.get('state'), expected, 'Initial value is first element in enum array');
 });


### PR DESCRIPTION
Currently, with our `schema-field-select` components, if both a `prompt` and a `default` value are missing, then the initial value of the component is `""`.  This is inconsistent with the default `<select>` behavior.  `<select>` tags missing a default option will default their value to that of the first non-disabled child option.  This PR updated `schema-field-select` to match the default behavior.
