### PR TITLE
Adds recommended label

### DIFF
--- a/addon/components/recommended-label/component.js
+++ b/addon/components/recommended-label/component.js
@@ -1,0 +1,19 @@
+import Ember from 'ember';
+export const DEFAULT_LABEL = `(recommended)`;
+
+export default Ember.Component.extend({
+  tagName: '',
+
+  recommendedValue: Ember.computed.alias('property.displayProperties.recommendedValue'),
+  recommendedLabel: Ember.computed('property.displayProperties.recommendedLabel', function() {
+    return this.get('property.displayProperties.recommendedLabel') || DEFAULT_LABEL;
+  }),
+
+  isRecommended: Ember.computed('value', 'recommendedValue', function() {
+    let { value, recommendedValue } = this.getProperties('value', 'recommendedValue');
+    if (Array.isArray(recommendedValue)) {
+      return recommendedValue.indexOf(value) > -1;
+    }
+    return recommendedValue === value;
+  })
+});

--- a/app/components/recommended-label/component.js
+++ b/app/components/recommended-label/component.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-json-schema-views/components/recommended-label/component';

--- a/app/templates/components/recommended-label.hbs
+++ b/app/templates/components/recommended-label.hbs
@@ -1,0 +1,1 @@
+{{#if isRecommended}}<span class='recommended-label'>{{recommendedLabel}}</span>{{/if}}

--- a/app/templates/components/schema-field-checkbox.hbs
+++ b/app/templates/components/schema-field-checkbox.hbs
@@ -9,7 +9,7 @@
   <div class="checkbox {{if property.readonly 'disabled' null}}">
     <label>
         {{input type="checkbox" checked=selected}}
-        <span>{{option}}</span>
+        <span>{{option}} {{recommended-label value=option property=property}}</span>
     </label>
   </div>
 {{/multiselect-checkboxes}}

--- a/app/templates/components/schema-field-select.hbs
+++ b/app/templates/components/schema-field-select.hbs
@@ -4,6 +4,6 @@
   {{/if}}
 
   {{#each property.validValues as |option|}}
-    <option selected={{if (eq value option) true null}} value={{option}}>{{option}}</option>
+    <option selected={{if (eq value option) true null}} value={{option}}>{{option}} <span>{{option}} {{recommended-label value=option property=property}}</span></option>
   {{/each}}
 </select>

--- a/tests/integration/components/schema-field-checkbox-test.js
+++ b/tests/integration/components/schema-field-checkbox-test.js
@@ -14,6 +14,10 @@ let schemaJson = {
       'items': {
         'type': 'string',
         'enum': allStates
+      },
+      'displayProperties': {
+        'recommendedValue': ['IN', 'CA'],
+        'recommendedLabel': '(recommended!)'
       }
     }
   }
@@ -36,10 +40,16 @@ test('Basic UI', function(assert) {
   });
 
   let checkedStates = ['IN', 'NY', 'CA'];
+  let recommendedStates = ['IN', 'CA'];
+  let recommendedTest = /recommended\!/;
   checkBoxes(checkedStates);
 
   checkedStates.forEach((state) => {
     assert.ok(getCheckbox(state).is(':checked'), `${state} is checked.`);
+  });
+
+  recommendedStates.forEach((state) => {
+    assert.ok(recommendedTest.test(getCheckbox(state).next('span').text()), 'has recommended label');
   });
 
   assert.deepEqual(this.document.get('states'), ['IN', 'NY', 'CA'], 'document values are set');

--- a/tests/integration/components/schema-field-select-test.js
+++ b/tests/integration/components/schema-field-select-test.js
@@ -8,7 +8,11 @@ let stateProperty = {
   'type': 'string',
   'default': 'NY',
   'enum': ['RI', 'NY', 'IN', 'CA', 'UT', 'CO'],
-  'title': 'State'
+  'title': 'State',
+  'displayProperties': {
+    'recommendedValue': 'CA',
+    'recommendedLabel': '(recommended!)'
+  }
 };
 
 let arraySchema = {
@@ -99,6 +103,18 @@ moduleForComponent('schema-field-select', {
     this.nestedKey = 'address.state';
     this.nestedProperty = this.objectProperties.address.properties.state;
   }
+});
+
+test('Recommneded values show recommended label', function(assert) {
+  let newItem = this.arrayDocument.addItem();
+  let recommendedTest = /recommended\!/;
+
+  this.setProperties({ key: this.key, property: this.arrayProperty, newItem });
+  this.render(hbs('{{schema-field-select key=key property=property document=newItem}}'));
+
+  let CAOption = this.$('select option:contains(CA)');
+  assert.ok(recommendedTest.test(CAOption.text()), 'shows recommended label');
+  assert.equal(this.$('select option').length, 6, 'has all 6 options');
 });
 
 // Test group 1: Adding item to array-base document


### PR DESCRIPTION
Previously, when we wanted our UI to recommend a value, we'd add "(recommended)" directly to the value. This means that we include "recommended" in our data directly.  Since what we recommend can change over time, this is a problem.  This PR adds support for a new "recommendedValue" display property.  If a given option matches the recommended value, then the "recommendedLabel" is displayed alongside that particular value.  "recommendedLabel" defaults to "(recommended)" but can be overloaded to something else from the schema.

"recommendedValue" supports a single string or an array of strings (for select multiple checkboxes)
